### PR TITLE
chore(onesky-bundle): update event dispatcher id service

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -83,25 +83,25 @@
             </call>
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\CheckTranslationProgressCommand" public="true" >
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
             <argument type="service" id="openclassrooms.onesky.services.language_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" command="openclassrooms:one-sky:check-translation-progress" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\PullCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" command="openclassrooms:one-sky:pull" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\PushCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" command="openclassrooms:one-sky:push" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\UpdateCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher" on-invalid="ignore" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" command="openclassrooms:one-sky:update" />

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -82,29 +82,29 @@
                 <argument type="string">%openclassrooms_onesky.source_locale%</argument>
             </call>
         </service>
-        <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\CheckTranslationProgressCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher.inner" />
+        <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\CheckTranslationProgressCommand" public="true" >
+            <argument type="service" id="debug.event_dispatcher" />
             <argument type="service" id="openclassrooms.onesky.services.language_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
-            <tag name="console.command" />
+            <tag name="console.command" command="openclassrooms:one-sky:check-translation-progress" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\PullCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher.inner" />
+            <argument type="service" id="debug.event_dispatcher" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
-            <tag name="console.command" />
+            <tag name="console.command" command="openclassrooms:one-sky:pull" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\PushCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher.inner" />
+            <argument type="service" id="debug.event_dispatcher" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
-            <tag name="console.command" />
+            <tag name="console.command" command="openclassrooms:one-sky:push" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\UpdateCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher.inner" />
+            <argument type="service" id="debug.event_dispatcher" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
-            <tag name="console.command" />
+            <tag name="console.command" command="openclassrooms:one-sky:update" />
         </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -83,25 +83,25 @@
             </call>
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\CheckTranslationProgressCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="openclassrooms.onesky.services.language_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\PullCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\PushCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" />
         </service>
         <service id="OpenClassrooms\Bundle\OneSkyBundle\Command\UpdateCommand" public="true">
-            <argument type="service" id="debug.event_dispatcher" />
+            <argument type="service" id="debug.event_dispatcher.inner" />
             <argument type="service" id="openclassrooms.onesky.services.translation_service" />
             <argument key="$projectId">%openclassrooms_onesky.project_id%</argument>
             <tag name="console.command" />


### PR DESCRIPTION
Looks like debug.event_dispatcher not exists anymore, and we have to use debug.event_dispatcher.inner to make this works.

I saw the error [here](https://git.prescreen.io/dev/ps/-/jobs/1427588), when using this bundle in the monolith